### PR TITLE
[CI/CD] Improve Docker development

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,22 +2,54 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    tags: ["v*.*.*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME_DOCKER_HUB: thmmniii/digital-classroom
 
 jobs:
-
   build:
-
+    name: Build and Deploy Docker images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag thmmniii/digital-classroom:latest
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_LOGIN }}
-        password: ${{ secrets.DOCKER_PWD }}
-    - name: Push the Docker image
-      run: docker push thmmniii/digital-classroom:latest
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log into registry DockerHub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PWD }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.5.1
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: ${{ env.IMAGE_NAME_DOCKER_HUB }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Improves the deployment of the Docker Container as follows:

- The Docker container is additionally deployed in the [Github Container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). As this offers a couple of advantages and is better linked to the repo.
- The Docker build is now cached which should improve the speed of CI/CD builds.
- Furthermore, the PR also changes which tag the Docker container is pushed with. A build on the master branch will create a container with the tag `master`. If a Relase (git tag) is created it will be created with the tags `latest` and the name of the Relase (e.g. 1.0.0). @snicki13  what do you think about this?

---

resolves #17 