### PR TITLE
[CI/CD] Fix test-system deployment

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,6 +55,7 @@ jobs:
           cache-to: type=gha,mode=max
           
   deploy:
+    name: Redeploy testsystem
     runs-on: ubuntu-latest
     needs: build
 

--- a/examples/deployment/restart-classroom.sh
+++ b/examples/deployment/restart-classroom.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 cd $CLASSROOM_DIR
+docker-compose pull classroom
 docker-compose up -d --remove-orphans classroom


### PR DESCRIPTION
The deployment of the `test-system` added in #32 does not work because the docker image is not re-pulled.