### PR TITLE
Fix docker registry publishing

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v2.7.0
         with:
           context: .
-          push: ${{ contains(github.ref, 'master') }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Publishing is skipped on version tag, because it is explicitly verified, that the ref is a push to master.

This should work. Inspired by https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md

---

resolves #71 