### PR TITLE
[CI/CD] Fix Changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate
+      - wontfix
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Fixed bugs 🐞
+      labels:
+        - bug
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Internal 🔒
+      labels:
+        - "CI/CD"
+        - Docker
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,23 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Get the Tag version
-        id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
-      - name: Generate Changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
-        id: changelog
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          futureRelease: ${{ steps.get_version.outputs.version }}
-          onlyLastTag: true
-          stripGeneratorNotice: true
-          pullRequests: false
-          enhancementLabels: ""
-          issuesLabel: "**Changes:**"
-          addSections: '{"internal":{"prefix":"**Internal:**","labels":["CI/CD","Docker"]}}'
       - name: Release
         uses: softprops/action-gh-release@v0.1.13
         with:
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, fromJson('["beta", "alpha"]')) }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,5 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v0.1.13
         with:
-          body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, fromJson('["beta", "alpha"]')) }}
           generate_release_notes: true


### PR DESCRIPTION
Since the old changelog generator did not work correctly, I replaced it with another one. Since Github now also supports this feature I decided to use this one (For more info see [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)).