### PR TITLE
Bump action-gh-release from 0.1.13 to 0.1.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Release
-        uses: softprops/action-gh-release@v0.1.13
+        uses: softprops/action-gh-release@v0.1.14 
         with:
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, fromJson('["beta", "alpha"]')) }}
           generate_release_notes: true


### PR DESCRIPTION
Bumps action-gh-release from 0.1.13 to 0.1.14

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/softprops/action-gh-release/releases/tag/v0.1.14">action-gh-release's releases</a>.</em></p>
<blockquote>
<h2>v0.1.14</h2>

This feature adds a new action input named generate_release_notes which when set to true, will automatically generate release notes for you based on GitHub activity. See the GitHub docs for the feature for more information.</li>

</blockquote>
</details>