### PR TITLE
[CI/CD][Docker CI] Only Login on Push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log into registry DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PWD }}
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,12 +26,14 @@ jobs:
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log into registry DockerHub
         uses: docker/login-action@v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PWD }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,11 +30,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log into registry DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_LOGIN }}
-          password: ${{ secrets.DOCKER_PWD }}
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
External pull requests do not have access to the environment variables, which is why the login to the Docker repository fails (see for example #116  and #114).